### PR TITLE
[a11y] Allow Form to accept an idSchema prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/react-jsonschema-form",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A simple React component capable of building HTML forms out of a JSON schema.",
   "scripts": {
     "build:readme": "toctoc README.md -w",
@@ -46,11 +46,11 @@
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "babel-register": "^6.18.0",
-    "codemirror": "^5.20.2",
-    "eslint": "^2.13.1",
     "chai": "^3.3.0",
+    "codemirror": "^5.20.2",
     "cross-env": "^2.0.1",
     "css-loader": "^0.23.1",
+    "eslint": "^2.13.1",
     "eslint-plugin-react": "^4.2.3",
     "estraverse": "^4.2.0",
     "estraverse-fb": "^1.3.1",

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -140,12 +140,10 @@ export default class Form extends Component {
       autocomplete,
       enctype,
       acceptcharset,
-      noHtml5Validate,
-      idSchema: originalIdSchema
+      noHtml5Validate
     } = this.props;
 
     const {schema, uiSchema, formData, errorSchema, idSchema} = this.state;
-
     const registry = this.getRegistry();
     const _SchemaField = registry.fields.SchemaField;
 

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -45,12 +45,10 @@ export default class Form extends Component {
         errors: state.errors || [],
         errorSchema: state.errorSchema || {}
       };
-    const idSchema = toIdSchema(schema, uiSchema["ui:rootFieldId"], definitions);
     return {
       status: "initial",
       schema,
       uiSchema,
-      idSchema,
       formData,
       edit,
       errors,
@@ -138,10 +136,13 @@ export default class Form extends Component {
       autocomplete,
       enctype,
       acceptcharset,
-      noHtml5Validate
+      noHtml5Validate,
+      idSchema: originalIdSchema
     } = this.props;
 
-    const {schema, uiSchema, formData, errorSchema, idSchema} = this.state;
+    const {schema, uiSchema, formData, errorSchema} = this.state;
+    const idSchema = originalIdSchema || toIdSchema(schema, uiSchema["ui:rootFieldId"], schema.definitions);
+
     const registry = this.getRegistry();
     const _SchemaField = registry.fields.SchemaField;
 

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -45,10 +45,14 @@ export default class Form extends Component {
         errors: state.errors || [],
         errorSchema: state.errorSchema || {}
       };
+
+    const {idSchema : originalIdSchema} = props;
+    const idSchema = originalIdSchema || toIdSchema(schema, uiSchema["ui:rootFieldId"], definitions);
     return {
       status: "initial",
       schema,
       uiSchema,
+      idSchema,
       formData,
       edit,
       errors,
@@ -140,8 +144,7 @@ export default class Form extends Component {
       idSchema: originalIdSchema
     } = this.props;
 
-    const {schema, uiSchema, formData, errorSchema} = this.state;
-    const idSchema = originalIdSchema || toIdSchema(schema, uiSchema["ui:rootFieldId"], schema.definitions);
+    const {schema, uiSchema, formData, errorSchema, idSchema} = this.state;
 
     const registry = this.getRegistry();
     const _SchemaField = registry.fields.SchemaField;

--- a/src/utils.js
+++ b/src/utils.js
@@ -385,17 +385,17 @@ export function shouldRender(comp, nextProps, nextState) {
   return !deepEquals(props, nextProps) || !deepEquals(state, nextState);
 }
 
-export function toIdSchema(schema, id, definitions) {
+export function toIdSchema(schema, id, definitions, idSuffix = "") {
   const idSchema = {
     $id: id || "root"
   };
 
   if ("$ref" in schema) {
     const _schema = retrieveSchema(schema, definitions);
-    return toIdSchema(_schema, id, definitions);
+    return toIdSchema(_schema, id, definitions, idSuffix);
   }
   if ("items" in schema && !schema.items.$ref) {
-    return toIdSchema(schema.items, id, definitions);
+    return toIdSchema(schema.items, id, definitions, idSuffix);
   }
   if (schema.type !== "object") {
     return idSchema;
@@ -403,8 +403,8 @@ export function toIdSchema(schema, id, definitions) {
 
   for (const name in schema.properties || {}) {
     const field = schema.properties[name];
-    const fieldId = `${idSchema.$id}_${name}`;
-    idSchema[name] = toIdSchema(field, fieldId, definitions);
+    const fieldId = `${idSchema.$id}_${name}${idSuffix}`;
+    idSchema[name] = toIdSchema(field, fieldId, definitions, idSuffix);
   }
   return idSchema;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -385,17 +385,17 @@ export function shouldRender(comp, nextProps, nextState) {
   return !deepEquals(props, nextProps) || !deepEquals(state, nextState);
 }
 
-export function toIdSchema(schema, id, definitions, idSuffix = "") {
+export function toIdSchema(schema, id, definitions) {
   const idSchema = {
     $id: id || "root"
   };
 
   if ("$ref" in schema) {
     const _schema = retrieveSchema(schema, definitions);
-    return toIdSchema(_schema, id, definitions, idSuffix);
+    return toIdSchema(_schema, id, definitions);
   }
   if ("items" in schema && !schema.items.$ref) {
-    return toIdSchema(schema.items, id, definitions, idSuffix);
+    return toIdSchema(schema.items, id, definitions);
   }
   if (schema.type !== "object") {
     return idSchema;
@@ -403,8 +403,8 @@ export function toIdSchema(schema, id, definitions, idSuffix = "") {
 
   for (const name in schema.properties || {}) {
     const field = schema.properties[name];
-    const fieldId = `${idSchema.$id}_${name}${idSuffix}`;
-    idSchema[name] = toIdSchema(field, fieldId, definitions, idSuffix);
+    const fieldId = `${idSchema.$id}_${name}`;
+    idSchema[name] = toIdSchema(field, fieldId, definitions);
   }
   return idSchema;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -389,6 +389,7 @@ export function toIdSchema(schema, id, definitions) {
   const idSchema = {
     $id: id || "root"
   };
+
   if ("$ref" in schema) {
     const _schema = retrieveSchema(schema, definitions);
     return toIdSchema(_schema, id, definitions);
@@ -399,9 +400,10 @@ export function toIdSchema(schema, id, definitions) {
   if (schema.type !== "object") {
     return idSchema;
   }
+
   for (const name in schema.properties || {}) {
     const field = schema.properties[name];
-    const fieldId = idSchema.$id + "_" + name;
+    const fieldId = `${idSchema.$id}_${name}`;
     idSchema[name] = toIdSchema(field, fieldId, definitions);
   }
   return idSchema;

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -1123,6 +1123,34 @@ describe("Form", () => {
     });
   });
 
+  describe("ID generation", () => {
+
+    it("should generate ids based on the schema properties", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          foo: {
+            type: "string",
+            minLength: 4
+          },
+          bar: {
+            type: "string"
+          },
+        },
+      };
+
+      const formProps = {
+        schema,
+        liveValidate: true,
+      };
+
+      const {node} = createFormComponent(formProps);
+
+      expect(node.querySelector("input#root_foo")).not.to.be.null;
+      expect(node.querySelector("input#root_bar")).not.to.be.null;
+    });
+  });
+
   describe("Attributes", () => {
     const formProps = {
       schema: {},

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -1123,7 +1123,7 @@ describe("Form", () => {
     });
   });
 
-  describe.only("ID generation", () => {
+  describe("ID generation", () => {
     const schema = {
       type: "object",
       properties: {
@@ -1148,6 +1148,19 @@ describe("Form", () => {
       expect(node.querySelector("input#root_foo")).not.to.be.null;
       expect(node.querySelector("input#root_bar")).not.to.be.null;
     });
+
+    it("should allow an optional idSchema prop to determine the name of the ids",()=> {
+      const  idSchema = {
+        "$id": "root",
+        foo: {"$id": "something_else"},
+        bar: {"$id": "surprise"},
+      };
+
+      const {node} = createFormComponent({...formProps, idSchema});
+
+      expect(node.querySelector("input#something_else")).not.to.be.null;
+      expect(node.querySelector("input#surprise")).not.to.be.null;
+    })
   });
 
   describe("Attributes", () => {

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -1123,27 +1123,26 @@ describe("Form", () => {
     });
   });
 
-  describe("ID generation", () => {
+  describe.only("ID generation", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        foo: {
+          type: "string",
+          minLength: 4
+        },
+        bar: {
+          type: "string"
+        },
+      },
+    };
+
+    const formProps = {
+      schema,
+      liveValidate: true,
+    };
 
     it("should generate ids based on the schema properties", () => {
-      const schema = {
-        type: "object",
-        properties: {
-          foo: {
-            type: "string",
-            minLength: 4
-          },
-          bar: {
-            type: "string"
-          },
-        },
-      };
-
-      const formProps = {
-        schema,
-        liveValidate: true,
-      };
-
       const {node} = createFormComponent(formProps);
 
       expect(node.querySelector("input#root_foo")).not.to.be.null;

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -577,6 +577,29 @@ describe("utils", () => {
         bar: {$id: "root_bar"}
       });
     });
+
+    it("should append an optional suffix to the ids of properties", () => {
+      const schema = {
+        definitions: {
+          testdef: {
+            type: "object",
+            properties: {
+              foo: {type: "string"},
+              bar: {type: "string"},
+            }
+          }
+        },
+        $ref: "#/definitions/testdef"
+      };
+
+      const suffix = 4;
+
+      expect(toIdSchema(schema, undefined, schema.definitions, suffix)).eql({
+        $id: "root",
+        foo: {$id: "root_foo4"},
+        bar: {$id: "root_bar4"},
+      });
+    });
   });
 
   describe("parseDateString()", () => {

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -577,29 +577,6 @@ describe("utils", () => {
         bar: {$id: "root_bar"}
       });
     });
-
-    it("should append an optional suffix to the ids of properties", () => {
-      const schema = {
-        definitions: {
-          testdef: {
-            type: "object",
-            properties: {
-              foo: {type: "string"},
-              bar: {type: "string"},
-            }
-          }
-        },
-        $ref: "#/definitions/testdef"
-      };
-
-      const suffix = 4;
-
-      expect(toIdSchema(schema, undefined, schema.definitions, suffix)).eql({
-        $id: "root",
-        foo: {$id: "root_foo4"},
-        bar: {$id: "root_bar4"},
-      });
-    });
   });
 
   describe("parseDateString()", () => {


### PR DESCRIPTION
### Reasons for making this change

We have a bug (https://github.com/department-of-veterans-affairs/va.gov-team/issues/12747) on our form review page involving the `ArrayField`. Each item in the array creates its own form, and each input node has an id that matches the corresponding input node for the other items in the array, which causes accessibility issues.

Once we leave the `ArrayField` (`vets-website`) and get into the `SchemaForm` (`vets-website`) component, we lose the context to know whether or not we are rendering multiple item forms, so we need to make some kind of intervention in the `ArrayField` component. Modifying the keys in the `schema` object so that they are indexed isn't great since this would require further changes to be made outside of the review page, and to app-specific code as well.

However, while in `ArrayField` (`vets-website`) if we can modify `idSchema` to be indexed, and then pass that down to `SchemaForm` (`vets-website`) and then onto `Form` (`react-jsonschema-form`), the `schema` can be left alone and we should be able to ensure that all ids are unique.


### Acceptance Criteria

- [x] DOM node `id`s can be customized for each form element
- [x] Tests are added

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
