### PR TITLE
Update react component checks to work with react 16.6+

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "jsonschema": "^1.0.2",
     "lodash.topath": "^4.5.2",
     "prop-types": "^15.6.1",
+    "react-is": "^17.0.1",
     "setimmediate": "^1.0.5"
   },
   "devDependencies": {
@@ -60,10 +61,10 @@
     "html": "0.0.10",
     "jsdom": "^8.3.0",
     "mocha": "^2.5.3",
-    "react": "^15.0.0",
-    "react-addons-test-utils": "^15.3.2",
+    "react": "^16.14.0",
+    "react-addons-test-utils": "^15.6.2",
     "react-codemirror": "^0.2.3",
-    "react-dom": "^15.3.2",
+    "react-dom": "^16.14.0",
     "react-transform-catch-errors": "^1.0.0",
     "react-transform-hmr": "^1.0.1",
     "redbox-react": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/react-jsonschema-form",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A simple React component capable of building HTML forms out of a JSON schema.",
   "scripts": {
     "build:readme": "toctoc README.md -w",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "jsdom": "^8.3.0",
     "mocha": "^2.5.3",
     "react": "^16.14.0",
-    "react-addons-test-utils": "^15.6.2",
     "react-codemirror": "^0.2.3",
     "react-dom": "^16.14.0",
     "react-transform-catch-errors": "^1.0.0",

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -23,13 +23,15 @@ const COMPONENT_TYPES = {
 
 function getFieldComponent(schema, uiSchema, fields) {
   const field = uiSchema["ui:field"];
+
+  if (typeof field !== "string" && ReactIs.isValidElementType(field)) {
+    return field;
+  }
+
   if (typeof field === "string" && field in fields) {
     return fields[field];
   }
 
-  if (ReactIs.isValidElementType(field)) {
-    return field;
-  }
   const componentName = COMPONENT_TYPES[schema.type];
   return componentName in fields ? fields[componentName] : UnsupportedField;
 }

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -1,6 +1,7 @@
 /* This file has been modified from the original forked source code */
 import PropTypes from "prop-types";
 import React from "react";
+import * as ReactIs from "react-is";
 
 import {
   isMultiSelect,
@@ -22,11 +23,12 @@ const COMPONENT_TYPES = {
 
 function getFieldComponent(schema, uiSchema, fields) {
   const field = uiSchema["ui:field"];
-  if (typeof field === "function") {
-    return field;
-  }
   if (typeof field === "string" && field in fields) {
     return fields[field];
+  }
+
+  if (ReactIs.isValidElementType(field)) {
+    return field;
   }
   const componentName = COMPONENT_TYPES[schema.type];
   return componentName in fields ? fields[componentName] : UnsupportedField;

--- a/src/components/widgets/FileWidget.js
+++ b/src/components/widgets/FileWidget.js
@@ -62,7 +62,7 @@ function extractFileInfo(dataURLs) {
 }
 
 class FileWidget extends Component {
-  defaultProps = {
+  static defaultProps = {
     multiple: false
   };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,6 @@
+/* This file has been modified from the original forked source code */
 import React from "react";
+import * as ReactIs from "react-is";
 import "setimmediate";
 
 
@@ -77,7 +79,7 @@ export function getWidget(schema, widget, registeredWidgets={}) {
     return Widget.MergedWidget;
   }
 
-  if (typeof widget === "function") {
+  if (typeof widget !== "string" && ReactIs.isValidElementType(widget)) {
     return mergeOptions(widget);
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -158,7 +158,7 @@ export function getUiOptions(uiSchema) {
   return Object.keys(uiSchema).filter(key => key.indexOf("ui:") === 0).reduce((options, key) => {
     const value = uiSchema[key];
 
-    if (key === "ui:widget" && isObject(value)) {
+    if (key === "ui:widget" && isObject(value) && !ReactIs.isValidElementType(value)) {
       console.warn("Setting options via ui:widget object is deprecated, use ui:options instead");
       return {...options, ...(value.options || {}), widget: value.component};
     }

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -3,7 +3,6 @@ import React from "react";
 
 import {expect} from "chai";
 import {Simulate} from "react-dom/test-utils";
-import {findDOMNode} from "react-dom";
 
 import {createFormComponent, createSandbox} from "./test_utils";
 

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -2,7 +2,8 @@
 import React from "react";
 
 import {expect} from "chai";
-import {Simulate} from "react-addons-test-utils";
+import {Simulate} from "react-dom/test-utils";
+import {findDOMNode} from "react-dom";
 
 import {createFormComponent, createSandbox} from "./test_utils";
 
@@ -214,6 +215,10 @@ describe("ArrayField", () => {
 
     it("should force revalidation when a field is removed", () => {
       // refs #195
+      // React 16 unmounts the component tree on errors, so we need to disable
+      // the automatic throwing of errors here
+      sandbox.restore();
+      sandbox.stub(console, "error", () => {});
       const {node} = createFormComponent({
         schema: {
           ...schema,
@@ -238,6 +243,7 @@ describe("ArrayField", () => {
 
       expect(node.querySelectorAll(".has-error .error-detail"))
         .to.have.length.of(0);
+      sandbox.restore();
     });
 
     it("should handle cleared field values in the array", () => {

--- a/test/BooleanField_test.js
+++ b/test/BooleanField_test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import {expect} from "chai";
-import {Simulate} from "react-addons-test-utils";
+import {Simulate} from "react-dom/test-utils";
 
 import {createFormComponent, createSandbox} from "./test_utils";
 

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -2,17 +2,17 @@
 import {expect} from "chai";
 import sinon from "sinon";
 import React from "react";
-import {renderIntoDocument, Simulate} from "react-addons-test-utils";
+import {renderIntoDocument, Simulate} from "react-dom/test-utils";
 import {findDOMNode} from "react-dom";
 
 import Form from "../src";
-import {createFormComponent, createSandbox} from "./test_utils";
+import {createFormComponent} from "./test_utils";
 
 describe("Form", () => {
   let sandbox;
 
   beforeEach(() => {
-    sandbox = createSandbox();
+    sandbox = sinon.sandbox.create();
   });
 
   afterEach(() => {

--- a/test/NumberField_test.js
+++ b/test/NumberField_test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import {expect} from "chai";
-import {Simulate} from "react-addons-test-utils";
+import {Simulate} from "react-dom/test-utils";
 
 import {createFormComponent, createSandbox} from "./test_utils";
 

--- a/test/ObjectField_test.js
+++ b/test/ObjectField_test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import {expect} from "chai";
-import {Simulate} from "react-addons-test-utils";
+import {Simulate} from "react-dom/test-utils";
 
 import {createFormComponent, createSandbox} from "./test_utils";
 

--- a/test/SchemaField_test.js
+++ b/test/SchemaField_test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import {expect} from "chai";
-import {Simulate} from "react-addons-test-utils";
+import {Simulate} from "react-dom/test-utils";
 
 import SchemaField from "../src/components/fields/SchemaField";
 import TitleField from "../src/components/fields/TitleField";
@@ -48,6 +48,7 @@ describe("SchemaField", () => {
         return <div id="custom"/>;
       }
     }
+    const MemoizedComponent = React.memo(() => <div id="custom2"/>);
 
     const schema = {
       type: "object",
@@ -76,6 +77,22 @@ describe("SchemaField", () => {
       const {node} = createFormComponent({schema, uiSchema});
 
       expect(node.querySelectorAll("#custom"))
+        .to.have.length.of(1);
+
+      expect(node.querySelectorAll("input"))
+        .to.have.length.of(1);
+
+      expect(node.querySelectorAll("label")).to.have.length.of(1);
+    });
+
+    it("should use provided memoized custom component for specific property", () => {
+      const uiSchema = {
+        foo: {"ui:field": MemoizedComponent}
+      };
+
+      const {node} = createFormComponent({schema, uiSchema});
+
+      expect(node.querySelectorAll("#custom2"))
         .to.have.length.of(1);
 
       expect(node.querySelectorAll("input"))

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -135,6 +135,20 @@ describe("StringField", () => {
       expect(node.querySelector("#custom"))
         .to.exist;
     });
+
+    it("should render customized memoized TextWidget", () => {
+      const {node} = createFormComponent({
+        schema: {
+          type: "string",
+        },
+        widgets: {
+          TextWidget: React.memo(CustomWidget)
+        }
+      });
+
+      expect(node.querySelector("#custom"))
+        .to.exist;
+    });
   });
 
   describe("SelectWidget", () => {

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -1,7 +1,7 @@
 /* This file has been modified from the original forked source code */
 import React from "react";
 import {expect} from "chai";
-import {Simulate} from "react-addons-test-utils";
+import {Simulate} from "react-dom/test-utils";
 
 import {parseDateString, toDateString} from "../src/utils";
 import {createFormComponent, createSandbox} from "./test_utils";

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -3,7 +3,7 @@
 
 import React from "react";
 import sinon from "sinon";
-import {renderIntoDocument, findRenderedComponentWithType} from "react-addons-test-utils";
+import {renderIntoDocument, findRenderedComponentWithType} from "react-dom/test-utils";
 import {findDOMNode, render} from "react-dom";
 
 import Form from "../src";

--- a/test/uiSchema_test.js
+++ b/test/uiSchema_test.js
@@ -1,7 +1,7 @@
 
 import {expect} from "chai";
 import React from "react";
-import {Simulate} from "react-addons-test-utils";
+import {Simulate} from "react-dom/test-utils";
 
 import {createFormComponent, createSandbox} from "./test_utils";
 

--- a/test/validate_test.js
+++ b/test/validate_test.js
@@ -1,6 +1,6 @@
 import {expect} from "chai";
 import sinon from "sinon";
-import {Simulate} from "react-addons-test-utils";
+import {Simulate} from "react-dom/test-utils";
 
 import validateFormData, {toErrorList} from "../src/validate";
 import {createFormComponent} from "./test_utils";


### PR DESCRIPTION
### Reasons for making this change

As of React 16.6, doing `typeof thing === 'function'` is not correct for determining if something is a React component. It could be wrapped in an object. This happens when using `React.memo`, for example. It limits the types of components that can be passed as custom fields and widgets.

In particular, it prevents components wrapped with `connect()` from newer versions of `react-redux` to be used in RJSF as custom fields or widgets.

In order to test this PR against the React.memo use case, I updated the version of React used in dev dependencies and fixed some unit test issues.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
