### PR TITLE
Stop submit propagation with prop

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -91,6 +91,9 @@ export default class Form extends Component {
 
   onSubmit = (event) => {
     event.preventDefault();
+    if (this.props.stopPropagation) {
+      event.stopPropagation();
+    }
     this.setState({status: "submitted"});
 
     if (!this.props.noValidate) {


### PR DESCRIPTION
### Reasons for making this change

I'm adding profile editing modals to our form's contact info page. The problem is that the modal renders a nested form. And clicking "update" inside the modal causes the "submit" event to propagate to the outer form causing the form to navigate to the next page.

I know nested form aren't allowed within the [HTML spec](https://html.spec.whatwg.org/multipage/forms.html#the-form-element):

> Content model:
> &nbsp;&nbsp;Flow content, but with no form element descendants.

But I could not find a way around it (ref the conversation from the first Slack link)

The only solution I found was to modify this library. I only call the `event.stopPropagation()` if a prop is passed to ensure I don't break something unintentionally.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/27137
- https://github.com/department-of-veterans-affairs/vets-website/pull/17831
- https://dsva.slack.com/archives/CBU0KDSB1/p1625846517423300
- https://dsva.slack.com/archives/CBU0KDSB1/p1626107406455800

If this is related to existing tickets, include links to them as well. Use the syntax `fixes #[issue number]` (ex: `fixes #123`).

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

