### PR TITLE
Prevent undefined is not an object error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/react-jsonschema-form",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A simple React component capable of building HTML forms out of a JSON schema.",
   "scripts": {
     "build:readme": "toctoc README.md -w",

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -33,7 +33,7 @@ export default class Form extends Component {
 
   getStateFromProps(props) {
     const state = this.state || {};
-    const schema = "schema" in props ? props.schema : this.props.schema;
+    const schema = "schema" in props ? props.schema : this.props.schema || {};
     const uiSchema = "uiSchema" in props ? props.uiSchema : this.props.uiSchema;
     const edit = typeof props.formData !== "undefined";
     const liveValidate = props.liveValidate || this.props.liveValidate;
@@ -122,7 +122,7 @@ export default class Form extends Component {
       widgets: {...widgets, ...this.props.widgets},
       ArrayFieldTemplate: this.props.ArrayFieldTemplate,
       FieldTemplate: this.props.FieldTemplate,
-      definitions: this.props.schema.definitions || {},
+      definitions: this.props.schema && this.props.schema.definitions || {},
       formContext: this.props.formContext || {},
     };
   }

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -182,7 +182,7 @@ class ArrayField extends Component {
 
   onAddClick = (event) => {
     event.preventDefault();
-    const {schema, registry, formData} = this.props;
+    const {schema, registry = {}, formData} = this.props;
     const {definitions} = registry;
     let itemSchema = schema.items;
     if (isFixedItems(schema) && allowAdditionalItems(schema)) {
@@ -266,7 +266,7 @@ class ArrayField extends Component {
       disabled,
       readonly,
       autofocus,
-      registry,
+      registry = {},
       formContext,
       onBlur
     } = this.props;
@@ -316,7 +316,7 @@ class ArrayField extends Component {
   renderMultiSelect() {
     const {schema, idSchema, uiSchema, disabled, readonly, autofocus, onBlur} = this.props;
     const items = this.props.formData;
-    const {widgets, definitions, formContext} = this.props.registry;
+    const {widgets, definitions, formContext} = this.props.registry || {};
     const itemsSchema = retrieveSchema(schema.items, definitions);
     const enumOptions = optionsList(itemsSchema);
     const {widget="select", ...options} = {...getUiOptions(uiSchema), enumOptions};
@@ -372,7 +372,7 @@ class ArrayField extends Component {
       disabled,
       readonly,
       autofocus,
-      registry,
+      registry = {},
       onBlur
     } = this.props;
     const title = schema.title || name;

--- a/src/utils.js
+++ b/src/utils.js
@@ -387,7 +387,7 @@ export function shouldRender(comp, nextProps, nextState) {
   return !deepEquals(props, nextProps) || !deepEquals(state, nextState);
 }
 
-export function toIdSchema(schema, id, definitions, idSuffix = "") {
+export function toIdSchema(schema, id, definitions = {}, idSuffix = "") {
   const idSchema = {
     $id: id || "root"
   };

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -1165,7 +1165,7 @@ describe("Form", () => {
 
   describe("Attributes", () => {
     const formProps = {
-      schema: {},
+      // schema: {}, // undefined to test fallback
       id: "test-form",
       className: "test-class other-class",
       name: "testName",


### PR DESCRIPTION
### Reasons for making this change

We're seeing a lot of Sentry events with a `undefined is not an object (evaluating 'n.definitions')`. This PR attempts to fix likely sources of that error, but these are guesses. We've just started logging save-in-progress IDs which will allow us to use the same form data that caused this error to occur. So eventually we should be able to isolate and fix the source of this error.

If this is related to existing tickets, include links to them as well.

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/29893
- http://sentry.vfs.va.gov/organizations/vsp/issues/49240

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests (partially)
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

I didn't add tests, but 