### PR TITLE
Prevent undefined error

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -33,7 +33,7 @@ export default class Form extends Component {
 
   getStateFromProps(props) {
     const state = this.state || {};
-    const schema = "schema" in props ? props.schema : this.props.schema || {};
+    const schema = ("schema" in props ? props.schema : this.props.schema) || {};
     const uiSchema = "uiSchema" in props ? props.uiSchema : this.props.uiSchema;
     const edit = typeof props.formData !== "undefined";
     const liveValidate = props.liveValidate || this.props.liveValidate;


### PR DESCRIPTION
### Reasons for making this change

We're still seeing `TypeError: undefined is not an object (evaluating 'n.definitions')`.

Checked the source of minified code to match the code inside the `getStateFromProps` function

- Latest error: http://sentry.vfs.va.gov/organizations/vsp/issues/52365/
- Original ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/29893

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
