### PR TITLE
Prevent undefined `definitions` error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/react-jsonschema-form",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "A simple React component capable of building HTML forms out of a JSON schema.",
   "scripts": {
     "build:readme": "toctoc README.md -w",

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -39,7 +39,7 @@ export default class Form extends Component {
     const liveValidate = props.liveValidate || this.props.liveValidate;
     const mustValidate = edit && !props.noValidate && liveValidate;
     const {definitions} = schema;
-    const formData = getDefaultFormState(schema, props.formData, definitions);
+    const formData = getDefaultFormState(schema, props.formData, definitions || {});
     const {errors, errorSchema} = mustValidate ?
       this.validate(formData, schema) : {
         errors: state.errors || [],
@@ -47,7 +47,7 @@ export default class Form extends Component {
       };
 
     const {idSchema : originalIdSchema} = props;
-    const idSchema = originalIdSchema || toIdSchema(schema, uiSchema["ui:rootFieldId"], definitions);
+    const idSchema = originalIdSchema || toIdSchema(schema, uiSchema["ui:rootFieldId"], definitions || {});
     return {
       status: "initial",
       schema,

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -190,7 +190,7 @@ class ArrayField extends Component {
     }
     this.props.onChange([
       ...formData,
-      getDefaultFormState(itemSchema, undefined, definitions)
+      getDefaultFormState(itemSchema, undefined, definitions || {})
     ], {validate: false});
   };
 
@@ -273,7 +273,7 @@ class ArrayField extends Component {
     const title = (schema.title === undefined) ? name : schema.title;
     const {ArrayFieldTemplate, definitions, fields} = registry;
     const {TitleField, DescriptionField} = fields;
-    const itemsSchema = retrieveSchema(schema.items, definitions);
+    const itemsSchema = retrieveSchema(schema.items, definitions || {});
     const {addable=true} = getUiOptions(uiSchema);
 
     const arrayProps = {
@@ -281,7 +281,7 @@ class ArrayField extends Component {
       items: formData.map((item, index) => {
         const itemErrorSchema = errorSchema ? errorSchema[index] : undefined;
         const itemIdPrefix = idSchema.$id + "_" + index;
-        const itemIdSchema = toIdSchema(itemsSchema, itemIdPrefix, definitions);
+        const itemIdSchema = toIdSchema(itemsSchema, itemIdPrefix, definitions || {});
         return this.renderArrayFieldItem({
           index,
           canMoveUp: index > 0,
@@ -317,7 +317,7 @@ class ArrayField extends Component {
     const {schema, idSchema, uiSchema, disabled, readonly, autofocus, onBlur} = this.props;
     const items = this.props.formData;
     const {widgets, definitions, formContext} = this.props.registry || {};
-    const itemsSchema = retrieveSchema(schema.items, definitions);
+    const itemsSchema = retrieveSchema(schema.items, definitions || {});
     const enumOptions = optionsList(itemsSchema);
     const {widget="select", ...options} = {...getUiOptions(uiSchema), enumOptions};
     const Widget = getWidget(schema, widget, widgets);
@@ -380,9 +380,9 @@ class ArrayField extends Component {
     const {ArrayFieldTemplate, definitions, fields} = registry;
     const {TitleField} = fields;
     const itemSchemas = schema.items.map(item =>
-      retrieveSchema(item, definitions));
+      retrieveSchema(item, definitions || {}));
     const additionalSchema = allowAdditionalItems(schema) ?
-      retrieveSchema(schema.additionalItems, definitions) : null;
+      retrieveSchema(schema.additionalItems, definitions || {}) : null;
     const {addable=true} = getUiOptions(uiSchema);
     const canAdd = addable && additionalSchema;
 
@@ -403,7 +403,7 @@ class ArrayField extends Component {
         const itemSchema = additional ?
           additionalSchema : itemSchemas[index];
         const itemIdPrefix = idSchema.$id + "_" + index;
-        const itemIdSchema = toIdSchema(itemSchema, itemIdPrefix, definitions);
+        const itemIdSchema = toIdSchema(itemSchema, itemIdPrefix, definitions || {});
         const itemUiSchema = additional ?
           uiSchema.additionalItems || {} :
           Array.isArray(uiSchema.items) ?

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -137,7 +137,7 @@ DefaultTemplate.defaultProps = {
 function SchemaField(props) {
   const {uiSchema, errorSchema, idSchema, name, required, registry} = props;
   const {definitions, fields, formContext, FieldTemplate = DefaultTemplate} = registry;
-  const schema = retrieveSchema(props.schema, definitions);
+  const schema = retrieveSchema(props.schema, definitions || {});
   const FieldComponent = getFieldComponent(schema, uiSchema, fields);
   const {DescriptionField} = fields;
   const disabled = Boolean(props.disabled || uiSchema["ui:disabled"]);


### PR DESCRIPTION
### Reasons for making this change

We're still seeing Sentry events with a `undefined is not an object (evaluating 'n.definitions')` error message. After attempting to match the code position within the event log, it is difficult to isolate a single source. So this PR attempts to replace all falsy `definitions` values with an empty object.

If this is related to existing tickets, include links to them as well.

- http://sentry.vfs.va.gov/organizations/vsp/issues/60670/
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/29893
- https://github.com/department-of-veterans-affairs/react-jsonschema-form/pull/11
- https://github.com/department-of-veterans-affairs/react-jsonschema-form/pull/12

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
