### PR TITLE
Add `ui:autocomplete`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/react-jsonschema-form",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "A simple React component capable of building HTML forms out of a JSON schema.",
   "scripts": {
     "build:readme": "toctoc README.md -w",

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -20,6 +20,10 @@ function BaseInput(props) {
   const _onChange = ({target: {value}}) => {
     return props.onChange(value === "" ? undefined : value);
   };
+  // see https://github.com/rjsf-team/react-jsonschema-form/pull/1705
+  if (options.autocomplete) {
+    inputProps.autoComplete = options.autocomplete;
+  }
   return (
     <input
       {...inputProps}

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -90,7 +90,7 @@ describe("StringField", () => {
 
       expect(onBlur.calledWith(input.id, "yo")).to.be.true;
     });
-    
+
     it("should handle an empty string change event", () => {
       const {comp, node} = createFormComponent({
         schema: {type: "string"},
@@ -148,6 +148,17 @@ describe("StringField", () => {
 
       expect(node.querySelector("#custom"))
         .to.exist;
+    });
+    it("should create and set autocomplete attribute", () => {
+      const { node } = createFormComponent({
+        schema: { type: "string" },
+        uiSchema: { "ui:autocomplete": "family-name" },
+        formData: undefined,
+      });
+
+      expect(node.querySelector("input").getAttribute("autocomplete")).eql(
+        "family-name"
+      );
     });
   });
 


### PR DESCRIPTION
### Reasons for making this change

To provide automated assistance in filling out form field values, as well as guidance to the browser as to the type of information expected in the field.

Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/37849
Docs: https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/779

Code copied from https://github.com/rjsf-team/react-jsonschema-form/pull/1705

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [x] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
