### PR TITLE
Pass CustomErrorList to Form

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,6 @@ render((
 ```
 
 #### Form error event handler
-z
 To react to when submitted form data are invalid, pass an `onError` handler, which is passed the list of encoutered errors:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ render((
 ```
 
 #### Form error event handler
-
+z
 To react to when submitted form data are invalid, pass an `onError` handler, which is passed the list of encoutered errors:
 
 ```js
@@ -1233,6 +1233,22 @@ To disable rendering of the error list at the top of the form, you can set the `
 render((
   <Form schema={schema}
         showErrorList={false}/>
+), document.getElementById("app"));
+```
+
+If `showErrorList` is `true`, you can pass in a custom error list component using the `CustomErrorList` property
+
+```js
+const CustomErrors = ({ errors }) => (
+  <va-alert status="error">
+    <h2 slot="headline">Errors!</h2>
+    <ul>{errors.map((error, i) => (<li key={i}>{error.stack}</li>))}</ul>
+  </va-alert>
+);
+
+render((
+  <Form schema={schema}
+        CustomErrorList={CustomErrors} />
 ), document.getElementById("app"));
 ```
 

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -71,10 +71,16 @@ export default class Form extends Component {
 
   renderErrors() {
     const {status, errors} = this.state;
-    const {showErrorList} = this.props;
+    const {showErrorList, CustomErrorList} = this.props;
 
-    if (status !== "editing" && errors.length && showErrorList != false) {
-      return <ErrorList errors={errors}/>;
+    if (
+      showErrorList != false &&
+      status !== "editing" &&
+      this.props.formContext.submitted &&
+      errors.length
+    ) {
+      return (CustomErrorList && <CustomErrorList errors={errors}/>) ||
+        <ErrorList errors={errors}/>;
     }
     return null;
   }

--- a/src/validate.js
+++ b/src/validate.js
@@ -44,21 +44,22 @@ function toErrorSchema(errors) {
   }, {});
 }
 
-export function toErrorList(errorSchema, fieldName = "root") {
+export function toErrorList(errorSchema, fieldName = "root", fieldPath) {
   // XXX: We should transform fieldName as a full field path string.
   let errorList = [];
   if ("__errors" in errorSchema) {
     errorList = errorList.concat(errorSchema.__errors.map(stack => {
       return {
         stack: `${fieldName}: ${stack}`,
-        name: fieldName,
+        fieldName,
+        fieldPath,
         error: stack
       };
     }));
   }
   return Object.keys(errorSchema).reduce((acc, key) => {
     if (key !== "__errors") {
-      acc = acc.concat(toErrorList(errorSchema[key], key));
+      acc = acc.concat(toErrorList(errorSchema[key], key, [...fieldPath, key]));
     }
     return acc;
   }, errorList);
@@ -115,7 +116,7 @@ export default function validateFormData(formData, schema, customValidate, trans
   // XXX: The errors list produced is not fully compliant with the format
   // exposed by the jsonschema lib, which contains full field paths and other
   // properties.
-  const newErrors = toErrorList(newErrorSchema);
+  const newErrors = toErrorList(newErrorSchema, "root", ["root"]);
 
   return {errors: newErrors, errorSchema: newErrorSchema};
 }

--- a/src/validate.js
+++ b/src/validate.js
@@ -50,7 +50,9 @@ export function toErrorList(errorSchema, fieldName = "root") {
   if ("__errors" in errorSchema) {
     errorList = errorList.concat(errorSchema.__errors.map(stack => {
       return {
-        stack: `${fieldName}: ${stack}`
+        stack: `${fieldName}: ${stack}`,
+        name: fieldName,
+        error: stack
       };
     }));
   }


### PR DESCRIPTION
### Reasons for making this change

Screen readers aren't reading out form error when focus is moved to the web component. So we're testing the error list shown above the form by setting the `showErrorList` property; but the component that is rendered isn't using the web components we would expect. So this PR:

- Adds `CustomErrorList` property to the `Form` component
- Add a check to prevent displaying the error list before the page is submitted (`formContext.submitted` is checked)
- Updated validate function to return `fieldName`, `fieldPath` and `error` separate from the error stack

| Before | After |
|---|---|
| <img width="525" alt="error-list-before" src="https://github.com/user-attachments/assets/16f16b36-7cad-4333-b9c9-e1a72e867d87"> | <img width="596" alt="error-list-after" src="https://github.com/user-attachments/assets/276d8491-6c15-476f-85db-67c661610ef9"> |

If this is related to existing tickets, include links to them as well.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/93251

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [x] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
